### PR TITLE
Add 'helpful' number in 'scrape_page_reviews'

### DIFF
--- a/amazon_scraper/app.py
+++ b/amazon_scraper/app.py
@@ -263,6 +263,8 @@ class AmazonScraper(object):
 						review['rating'] = box.find("i", {"class":"review-rating"}).span.text
 						review['author'] = box.find("a", {"class":"author"}).text
 						review['author_id'] = box.find("a", {"class":"author"}).get('href').split('/')[4]
+						x = (lambda text : 0 if text == None else text.text.split(' ')[0])(box.find('span', {'class': 'cr-vote-text'}))
+						review['helpful'] = (lambda x : x if x != 'One' else 0)(x)
 						results.put(review)
 
 					self.logger.info("finished scraping " + url)


### PR DESCRIPTION
Hello,
First of all, thank you for developing this scraper.

I was able to get review data by using this file.
However, there was another content I needed when I was scraping data, it is 'helpful' count. I would like to add 'helpful' count in scrape_page_reviews function. I think it would be more useful for people who want to get 'helpful' data in review data by using this scraper like me if it would be added.

Thank you for your time.